### PR TITLE
Update VNF LCM Workflow and implemente automatic VNF LCM operations.

### DIFF
--- a/ETSI/Python/_py__NFVI_Resources_Management/.meta__py__NFVI_Resources_Management.xml
+++ b/ETSI/Python/_py__NFVI_Resources_Management/.meta__py__NFVI_Resources_Management.xml
@@ -7,7 +7,7 @@
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1643706447022</value>
+            <value>1643882409508</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1643706447018</value>
+            <value>1643882409500</value>
         </entry>
         <entry>
             <key>MODEL</key>

--- a/ETSI/Python/_py__NFVI_Resources_Management/_py__NFVI_Resources_Management.xml
+++ b/ETSI/Python/_py__NFVI_Resources_Management/_py__NFVI_Resources_Management.xml
@@ -42,7 +42,7 @@
     </task>
   </process>
   <process name="Process/Telekom_Malaysia/_py__NFVI_Resources_Management/Process_Subscribe_VNFM_to_NFVO">
-    <displayName>Subscribe VNFM and NFVO</displayName>
+    <displayName>Register VNFM and NFVO</displayName>
     <type>UPDATE</type>
     <visibility>5</visibility>
     <allowSchedule/>

--- a/ETSI/Python/_py__VNF_Instance_HEAL/.meta_Process_Trigger_automatic_healing
+++ b/ETSI/Python/_py__VNF_Instance_HEAL/.meta_Process_Trigger_automatic_healing
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata>
+    <map>
+        <entry>
+            <key>DISPLAYNAME</key>
+            <value>Process_Trigger_automatic_scaling_operation</value>
+        </entry>
+        <entry>
+            <key>DATE_MODIFICATION</key>
+            <value>1642006736891</value>
+        </entry>
+        <entry>
+            <key>REPOSITORY</key>
+            <value>Process</value>
+        </entry>
+        <entry>
+            <key>DATE_CREATION</key>
+            <value>1642006736888</value>
+        </entry>
+        <entry>
+            <key>TAG</key>
+        </entry>
+        <entry>
+            <key>TYPE</key>
+            <value>DIRECTORY</value>
+        </entry>
+        <entry>
+            <key>COMMENT</key>
+        </entry>
+    </map>
+</metadata>

--- a/ETSI/Python/_py__VNF_Instance_HEAL/.meta__py__VNF_Instance_HEAL.xml
+++ b/ETSI/Python/_py__VNF_Instance_HEAL/.meta__py__VNF_Instance_HEAL.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata>
+    <map>
+        <entry>
+            <key>DISPLAYNAME</key>
+            <value>_py__VNF_Instance_HEAL.xml</value>
+        </entry>
+        <entry>
+            <key>DATE_MODIFICATION</key>
+            <value>1643966156982</value>
+        </entry>
+        <entry>
+            <key>REPOSITORY</key>
+            <value>Process</value>
+        </entry>
+        <entry>
+            <key>DATE_CREATION</key>
+            <value>1643966156979</value>
+        </entry>
+        <entry>
+            <key>MODEL</key>
+            <value>0</value>
+        </entry>
+        <entry>
+            <key>TAG</key>
+        </entry>
+        <entry>
+            <key>FILE_TYPE</key>
+            <value>text</value>
+        </entry>
+        <entry>
+            <key>MANUFACTURER</key>
+            <value>0</value>
+        </entry>
+        <entry>
+            <key>TYPE</key>
+            <value>FILE</value>
+        </entry>
+        <entry>
+            <key>COMMENT</key>
+        </entry>
+    </map>
+</metadata>

--- a/ETSI/Python/_py__VNF_Instance_HEAL/Process_Trigger_automatic_healing/.meta_Tasks
+++ b/ETSI/Python/_py__VNF_Instance_HEAL/Process_Trigger_automatic_healing/.meta_Tasks
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata>
+    <map>
+        <entry>
+            <key>DISPLAYNAME</key>
+            <value>Tasks</value>
+        </entry>
+        <entry>
+            <key>DATE_MODIFICATION</key>
+            <value>1642006736928</value>
+        </entry>
+        <entry>
+            <key>REPOSITORY</key>
+            <value>Process</value>
+        </entry>
+        <entry>
+            <key>DATE_CREATION</key>
+            <value>1642006736925</value>
+        </entry>
+        <entry>
+            <key>TAG</key>
+        </entry>
+        <entry>
+            <key>TYPE</key>
+            <value>DIRECTORY</value>
+        </entry>
+        <entry>
+            <key>COMMENT</key>
+        </entry>
+    </map>
+</metadata>

--- a/ETSI/Python/_py__VNF_Instance_HEAL/Process_Trigger_automatic_healing/Tasks/.meta_Task_automatic_vnf_healing_operation.py
+++ b/ETSI/Python/_py__VNF_Instance_HEAL/Process_Trigger_automatic_healing/Tasks/.meta_Task_automatic_vnf_healing_operation.py
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata>
+    <map>
+        <entry>
+            <key>DISPLAYNAME</key>
+            <value>Task_automatic_vnf_healing_operation.py</value>
+        </entry>
+        <entry>
+            <key>DATE_MODIFICATION</key>
+            <value>1643966156248</value>
+        </entry>
+        <entry>
+            <key>REPOSITORY</key>
+            <value>Process</value>
+        </entry>
+        <entry>
+            <key>DATE_CREATION</key>
+            <value>1643966156245</value>
+        </entry>
+        <entry>
+            <key>TAG</key>
+        </entry>
+        <entry>
+            <key>FILE_TYPE</key>
+            <value>text</value>
+        </entry>
+        <entry>
+            <key>TYPE</key>
+            <value>UPLOAD</value>
+        </entry>
+        <entry>
+            <key>COMMENT</key>
+        </entry>
+    </map>
+</metadata>

--- a/ETSI/Python/_py__VNF_Instance_HEAL/Process_Trigger_automatic_healing/Tasks/Task_automatic_vnf_healing_operation.py
+++ b/ETSI/Python/_py__VNF_Instance_HEAL/Process_Trigger_automatic_healing/Tasks/Task_automatic_vnf_healing_operation.py
@@ -1,0 +1,99 @@
+import json
+import time
+from msa_sdk import constants
+from msa_sdk.orchestration import Orchestration
+from msa_sdk.variables import Variables
+from msa_sdk.msa_api import MSA_API
+from msa_sdk.device import Device
+
+'''
+allows to get configuration variable value.
+'''
+def _get_configuration_variable(device, name):
+    value = ''
+    ret = device.get_configuration_variable(name)
+    if 'value' in ret:
+        value = ret.get('value')
+        return value
+    return ''
+
+'''
+Retrieve process instance by service instance ID.
+
+@param orch:
+    Ochestration class object reference.
+@param service_id:
+    Baseline workflow service instance ID.
+@param timeout:
+    loop duration before to break.
+@param interval:
+    loop time interval.
+@return:
+    Response of the get process instance execution.
+'''
+def get_process_instance(orch, process_id, timeout = 600, interval=5):
+    response = {}
+    global_timeout = time.time() + timeout
+    while True:
+        #get service instance execution status.
+        orch.get_process_instance(process_id)
+        response = json.loads(orch.content)
+        status = response.get('status').get('status')
+        #context.update(get_process_instance=status)
+        if status != constants.RUNNING or time.time() > global_timeout:
+            break
+        time.sleep(interval)
+
+    return response
+
+if __name__ == "__main__":
+
+    dev_var = Variables()
+    dev_var.add('customer_id', var_type='String')
+    dev_var.add('device_id', var_type='Device')
+    dev_var.add('rawlog', var_type='String')
+    context = Variables.task_call(dev_var)
+    
+    #Get device id (router) from context.
+    device_id = context['device_id'][3:]
+    
+    #Initiate orchestraction object.
+    ubiqube_id = context['UBIQUBEID']
+    orch = Orchestration(ubiqube_id)
+    
+    #Initiate Device object
+    device = Device(device_id=device_id)
+    
+    #Static Routing Management WF service name constant variable.
+    SERVICE_NAME = 'Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/_py__VNF_LCM__VNFD_based-on_SOL001_'
+    SCALE_OUT_PROCESS_NAME = 'Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Heal_VNF'
+    service_id = ''
+    service_ext_ref = ''
+    
+    #Prepare the VNF LCM WF scale out input parameter as API body.
+    data = dict()
+    
+    if isinstance(data, dict):
+        try:
+            config_var_vnflcm_wf_service_instance_ref = "vnflcm_wf_service_instance_ref"
+            service_ext_ref = _get_configuration_variable(device, config_var_vnflcm_wf_service_instance_ref)
+            context.update(config_var_vnflcm_wf_service_instance_ref=config_var_vnflcm_wf_service_instance_ref)
+        except:
+            MSA_API.task_error('vnflcm service instance reference variable (' + config_var_vnflcm_wf_service_instance_ref + ') is missing from ME=' + device_id, context, True)
+        
+        if not service_ext_ref:
+            MSA_API.task_error('VNF LCM Service instance reference is missing from ME config vars: id=' + device_id, context, True)
+        #execute service by ref.
+        orch.execute_service_by_reference(ubiqube_id, service_ext_ref, SERVICE_NAME, SCALE_OUT_PROCESS_NAME, data)
+        response = json.loads(orch.content)
+        context.update(vnflcm_response=response)
+        service_id = response.get('serviceId').get('id')
+        process_id = response.get('processId').get('id')
+        #get service process details.
+        response = get_process_instance(orch, process_id)
+        status = response.get('status').get('status')
+        details = response.get('status').get('details')
+        if status == constants.FAILED:
+            MSA_API.task_error('Execute service operation is failed: ' + details + ' (#' + str(service_id) + ')', context, True)
+        
+    MSA_API.task_success( 'VNF Instance SCALE_OUT operation is successfully executed.', context, True)

--- a/ETSI/Python/_py__VNF_Instance_HEAL/_py__VNF_Instance_HEAL.xml
+++ b/ETSI/Python/_py__VNF_Instance_HEAL/_py__VNF_Instance_HEAL.xml
@@ -1,0 +1,28 @@
+<ObjectDefinition>
+  <variables frozen="0">
+    <variable displayName="customer_id" name="params.customer_id" startIncrement="0" type="String" mandatoryArray="false" visible="true" description="" groupSeparator="" groupDisplayName="" displayOrder="0" increment="0" refServiceURI="" keepOnImport="false" editable="false" onlyDetailView="false" localVarNameMatch="" remoteVarNameMatch="" arrayCanAdd="true" arrayCanRemove="true" arrayCanMove="true" arrayCanEdit="true" displayNameHeader="" fullDisplayName="" isMandatory="false" isUserLocked="false" isGrouped="false" isSearchable="false" isUniqueGlobal="false"/>
+    <variable displayName="device_id" name="params.device_id" startIncrement="0" type="Device" mandatoryArray="false" visible="true" description="" groupSeparator="" groupDisplayName="" displayOrder="0" increment="0" refServiceURI="" keepOnImport="false" editable="false" onlyDetailView="false" localVarNameMatch="" remoteVarNameMatch="" arrayCanAdd="true" arrayCanRemove="true" arrayCanMove="true" arrayCanEdit="true" displayNameHeader="" fullDisplayName="" isMandatory="false" isUserLocked="false" isGrouped="false" isSearchable="false" isUniqueGlobal="false"/>
+    <variable displayName="rawlog" name="params.rawlog" startIncrement="0" type="String" mandatoryArray="false" visible="true" description="" groupSeparator="" groupDisplayName="" displayOrder="0" increment="0" refServiceURI="" keepOnImport="false" editable="false" onlyDetailView="false" localVarNameMatch="" remoteVarNameMatch="" arrayCanAdd="true" arrayCanRemove="true" arrayCanMove="true" arrayCanEdit="true" displayNameHeader="" fullDisplayName="" isMandatory="false" isUserLocked="false" isGrouped="false" isSearchable="false" isUniqueGlobal="false"/>
+  </variables>
+  <example/>
+  <process name="Process/Telekom_Malaysia/_py__VNF_Instance_HEAL/Process_Trigger_automatic_healing">
+    <displayName>Heal VNF Instance</displayName>
+    <type>CREATE</type>
+    <visibility>5</visibility>
+    <allowSchedule/>
+    <task name="Task_automatic_vnf_healing_operation.py">
+      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_Instance_HEAL/Process_Trigger_automatic_healing/Tasks</processPath>
+      <displayName>Trigger automatic VNF Heal</displayName>
+    </task>
+  </process>
+  <information>
+    <icon/>
+    <description>This workflow allows to schedule automatic VNF Heal operation based-on alarm management.</description>
+    <displayField>service_id</displayField>
+    <serviceTaskType>python</serviceTaskType>
+    <order>10000</order>
+    <visibility>5</visibility>
+    <name>[Py] VNF Instance Heal</name>
+    <group>ETSI|PYTHON|VNF</group>
+  </information>
+</ObjectDefinition>

--- a/ETSI/Python/_py__VNF_Instance_SCALE_IN/.meta_Process_Trigger_automatic_scaling_operation
+++ b/ETSI/Python/_py__VNF_Instance_SCALE_IN/.meta_Process_Trigger_automatic_scaling_operation
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata>
+    <map>
+        <entry>
+            <key>DISPLAYNAME</key>
+            <value>Process_Trigger_automatic_scaling_operation</value>
+        </entry>
+        <entry>
+            <key>DATE_MODIFICATION</key>
+            <value>1642006736891</value>
+        </entry>
+        <entry>
+            <key>REPOSITORY</key>
+            <value>Process</value>
+        </entry>
+        <entry>
+            <key>DATE_CREATION</key>
+            <value>1642006736888</value>
+        </entry>
+        <entry>
+            <key>TAG</key>
+        </entry>
+        <entry>
+            <key>TYPE</key>
+            <value>DIRECTORY</value>
+        </entry>
+        <entry>
+            <key>COMMENT</key>
+        </entry>
+    </map>
+</metadata>

--- a/ETSI/Python/_py__VNF_Instance_SCALE_IN/.meta__py__VNF_Instance_SCALE_IN.xml
+++ b/ETSI/Python/_py__VNF_Instance_SCALE_IN/.meta__py__VNF_Instance_SCALE_IN.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata>
+    <map>
+        <entry>
+            <key>DISPLAYNAME</key>
+            <value>_py__VNF_Instance_SCALE_IN.xml</value>
+        </entry>
+        <entry>
+            <key>DATE_MODIFICATION</key>
+            <value>1643962526006</value>
+        </entry>
+        <entry>
+            <key>REPOSITORY</key>
+            <value>Process</value>
+        </entry>
+        <entry>
+            <key>DATE_CREATION</key>
+            <value>1643962526002</value>
+        </entry>
+        <entry>
+            <key>MODEL</key>
+            <value>0</value>
+        </entry>
+        <entry>
+            <key>TAG</key>
+        </entry>
+        <entry>
+            <key>FILE_TYPE</key>
+            <value>unknown</value>
+        </entry>
+        <entry>
+            <key>MANUFACTURER</key>
+            <value>0</value>
+        </entry>
+        <entry>
+            <key>TYPE</key>
+            <value>FILE</value>
+        </entry>
+        <entry>
+            <key>COMMENT</key>
+        </entry>
+    </map>
+</metadata>

--- a/ETSI/Python/_py__VNF_Instance_SCALE_IN/Process_Trigger_automatic_scaling_operation/.meta_Tasks
+++ b/ETSI/Python/_py__VNF_Instance_SCALE_IN/Process_Trigger_automatic_scaling_operation/.meta_Tasks
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata>
+    <map>
+        <entry>
+            <key>DISPLAYNAME</key>
+            <value>Tasks</value>
+        </entry>
+        <entry>
+            <key>DATE_MODIFICATION</key>
+            <value>1642006736928</value>
+        </entry>
+        <entry>
+            <key>REPOSITORY</key>
+            <value>Process</value>
+        </entry>
+        <entry>
+            <key>DATE_CREATION</key>
+            <value>1642006736925</value>
+        </entry>
+        <entry>
+            <key>TAG</key>
+        </entry>
+        <entry>
+            <key>TYPE</key>
+            <value>DIRECTORY</value>
+        </entry>
+        <entry>
+            <key>COMMENT</key>
+        </entry>
+    </map>
+</metadata>

--- a/ETSI/Python/_py__VNF_Instance_SCALE_IN/Process_Trigger_automatic_scaling_operation/Tasks/.meta_Task_Trigger_automatic_VNF_Instance_scaling__Out_In__operation.py
+++ b/ETSI/Python/_py__VNF_Instance_SCALE_IN/Process_Trigger_automatic_scaling_operation/Tasks/.meta_Task_Trigger_automatic_VNF_Instance_scaling__Out_In__operation.py
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata>
+    <map>
+        <entry>
+            <key>DISPLAYNAME</key>
+            <value>Task_Trigger_automatic_VNF_Instance_scaling__Out_In__operation.py</value>
+        </entry>
+        <entry>
+            <key>DATE_MODIFICATION</key>
+            <value>1643962524965</value>
+        </entry>
+        <entry>
+            <key>REPOSITORY</key>
+            <value>Process</value>
+        </entry>
+        <entry>
+            <key>DATE_CREATION</key>
+            <value>1643962524963</value>
+        </entry>
+        <entry>
+            <key>TAG</key>
+        </entry>
+        <entry>
+            <key>FILE_TYPE</key>
+            <value>text</value>
+        </entry>
+        <entry>
+            <key>TYPE</key>
+            <value>UPLOAD</value>
+        </entry>
+        <entry>
+            <key>COMMENT</key>
+        </entry>
+    </map>
+</metadata>

--- a/ETSI/Python/_py__VNF_Instance_SCALE_IN/Process_Trigger_automatic_scaling_operation/Tasks/Task_Trigger_automatic_VNF_Instance_scaling__Out_In__operation.py
+++ b/ETSI/Python/_py__VNF_Instance_SCALE_IN/Process_Trigger_automatic_scaling_operation/Tasks/Task_Trigger_automatic_VNF_Instance_scaling__Out_In__operation.py
@@ -1,0 +1,103 @@
+import json
+import time
+from msa_sdk import constants
+from msa_sdk.orchestration import Orchestration
+from msa_sdk.variables import Variables
+from msa_sdk.msa_api import MSA_API
+from msa_sdk.device import Device
+
+'''
+allows to get configuration variable value.
+'''
+def _get_configuration_variable(device, name):
+    value = ''
+    ret = device.get_configuration_variable(name)
+    if 'value' in ret:
+        value = ret.get('value')
+        return value
+    return ''
+
+'''
+Retrieve process instance by service instance ID.
+
+@param orch:
+    Ochestration class object reference.
+@param service_id:
+    Baseline workflow service instance ID.
+@param timeout:
+    loop duration before to break.
+@param interval:
+    loop time interval.
+@return:
+    Response of the get process instance execution.
+'''
+def get_process_instance(orch, process_id, timeout = 600, interval=5):
+    response = {}
+    global_timeout = time.time() + timeout
+    while True:
+        #get service instance execution status.
+        orch.get_process_instance(process_id)
+        response = json.loads(orch.content)
+        status = response.get('status').get('status')
+        #context.update(get_process_instance=status)
+        if status != constants.RUNNING or time.time() > global_timeout:
+            break
+        time.sleep(interval)
+
+    return response
+
+if __name__ == "__main__":
+
+    dev_var = Variables()
+    dev_var.add('customer_id', var_type='String')
+    dev_var.add('device_id', var_type='Device')
+    dev_var.add('rawlog', var_type='String')
+    context = Variables.task_call(dev_var)
+    
+    #Get device id (router) from context.
+    device_id = context['device_id'][3:]
+    
+    #Initiate orchestraction object.
+    ubiqube_id = context['UBIQUBEID']
+    orch = Orchestration(ubiqube_id)
+    
+    #Initiate Device object
+    device = Device(device_id=device_id)
+    
+    #Static Routing Management WF service name constant variable.
+    SERVICE_NAME = 'Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/_py__VNF_LCM__VNFD_based-on_SOL001_'
+    SCALE_OUT_PROCESS_NAME = 'Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF'
+    service_id = ''
+    service_ext_ref = ''
+    
+    #Prepare the VNF LCM WF scale out input parameter as API body.
+    
+    aspectId = "vsrx" #this value is defined in the VNF Descriptor (.csar file).
+    numberOfSteps = "1" #Default value.
+    
+    data = dict(aspectId=aspectId, numberOfSteps=numberOfSteps)
+    
+    if isinstance(data, dict):
+        try:
+            config_var_vnflcm_wf_service_instance_ref = "vnflcm_wf_service_instance_ref"
+            service_ext_ref = _get_configuration_variable(device, config_var_vnflcm_wf_service_instance_ref)
+            context.update(config_var_vnflcm_wf_service_instance_ref=config_var_vnflcm_wf_service_instance_ref)
+        except:
+            MSA_API.task_error('vnflcm service instance reference variable (' + config_var_vnflcm_wf_service_instance_ref + ') is missing from ME=' + device_id, context, True)
+        
+        if not service_ext_ref:
+            MSA_API.task_error('VNF LCM Service instance reference is missing from ME config vars: id=' + device_id, context, True)
+        #execute service by ref.
+        orch.execute_service_by_reference(ubiqube_id, service_ext_ref, SERVICE_NAME, SCALE_OUT_PROCESS_NAME, data)
+        response = json.loads(orch.content)
+        context.update(vnflcm_response=response)
+        service_id = response.get('serviceId').get('id')
+        process_id = response.get('processId').get('id')
+        #get service process details.
+        response = get_process_instance(orch, process_id)
+        status = response.get('status').get('status')
+        details = response.get('status').get('details')
+        if status == constants.FAILED:
+            MSA_API.task_error('Execute service operation is failed: ' + details + ' (#' + str(service_id) + ')', context, True)
+        
+    MSA_API.task_success( 'VNF Instance SCALE_IN operation is successfully executed.', context, True)

--- a/ETSI/Python/_py__VNF_Instance_SCALE_IN/_py__VNF_Instance_SCALE_IN.xml
+++ b/ETSI/Python/_py__VNF_Instance_SCALE_IN/_py__VNF_Instance_SCALE_IN.xml
@@ -1,0 +1,28 @@
+<ObjectDefinition>
+  <variables frozen="0">
+    <variable displayName="customer_id" name="params.customer_id" startIncrement="0" type="String" mandatoryArray="false" visible="true" description="" groupSeparator="" groupDisplayName="" displayOrder="0" increment="0" refServiceURI="" keepOnImport="false" editable="false" onlyDetailView="false" localVarNameMatch="" remoteVarNameMatch="" arrayCanAdd="true" arrayCanRemove="true" arrayCanMove="true" arrayCanEdit="true" displayNameHeader="" fullDisplayName="" isMandatory="false" isUserLocked="false" isGrouped="false" isSearchable="false" isUniqueGlobal="false"/>
+    <variable displayName="device_id" name="params.device_id" startIncrement="0" type="Device" mandatoryArray="false" visible="true" description="" groupSeparator="" groupDisplayName="" displayOrder="0" increment="0" refServiceURI="" keepOnImport="false" editable="false" onlyDetailView="false" localVarNameMatch="" remoteVarNameMatch="" arrayCanAdd="true" arrayCanRemove="true" arrayCanMove="true" arrayCanEdit="true" displayNameHeader="" fullDisplayName="" isMandatory="false" isUserLocked="false" isGrouped="false" isSearchable="false" isUniqueGlobal="false"/>
+    <variable displayName="rawlog" name="params.rawlog" startIncrement="0" type="String" mandatoryArray="false" visible="true" description="" groupSeparator="" groupDisplayName="" displayOrder="0" increment="0" refServiceURI="" keepOnImport="false" editable="false" onlyDetailView="false" localVarNameMatch="" remoteVarNameMatch="" arrayCanAdd="true" arrayCanRemove="true" arrayCanMove="true" arrayCanEdit="true" displayNameHeader="" fullDisplayName="" isMandatory="false" isUserLocked="false" isGrouped="false" isSearchable="false" isUniqueGlobal="false"/>
+  </variables>
+  <example/>
+  <process name="Process/Telekom_Malaysia/_py__VNF_Instance_SCALE_IN/Process_Trigger_automatic_scaling_operation">
+    <displayName>SCALE_IN VNF Instance</displayName>
+    <type>CREATE</type>
+    <visibility>5</visibility>
+    <allowSchedule/>
+    <task name="Task_Trigger_automatic_VNF_Instance_scaling__Out_In__operation.py">
+      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_Instance_SCALE_IN/Process_Trigger_automatic_scaling_operation/Tasks</processPath>
+      <displayName>Trigger automatic VNF Instance scaling (Out/In) operation</displayName>
+    </task>
+  </process>
+  <information>
+    <icon/>
+    <description>This workflow allows to schedule automatic VNF Scale IN operation based-on alarm management.</description>
+    <displayField>service_id</displayField>
+    <serviceTaskType>python</serviceTaskType>
+    <order>10000</order>
+    <visibility>5</visibility>
+    <name>[Py] VNF Instance SCALE_IN</name>
+    <group>ETSI|PYTHON|VNF</group>
+  </information>
+</ObjectDefinition>

--- a/ETSI/Python/_py__VNF_Instance_SCALE_OUT/.meta_Process_Trigger_automatic_scaling_operation
+++ b/ETSI/Python/_py__VNF_Instance_SCALE_OUT/.meta_Process_Trigger_automatic_scaling_operation
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata>
+    <map>
+        <entry>
+            <key>DISPLAYNAME</key>
+            <value>Process_Trigger_automatic_scaling_operation</value>
+        </entry>
+        <entry>
+            <key>DATE_MODIFICATION</key>
+            <value>1642006736891</value>
+        </entry>
+        <entry>
+            <key>REPOSITORY</key>
+            <value>Process</value>
+        </entry>
+        <entry>
+            <key>DATE_CREATION</key>
+            <value>1642006736888</value>
+        </entry>
+        <entry>
+            <key>TAG</key>
+        </entry>
+        <entry>
+            <key>TYPE</key>
+            <value>DIRECTORY</value>
+        </entry>
+        <entry>
+            <key>COMMENT</key>
+        </entry>
+    </map>
+</metadata>

--- a/ETSI/Python/_py__VNF_Instance_SCALE_OUT/.meta__py__VNF_Instance_SCALE_OUT.xml
+++ b/ETSI/Python/_py__VNF_Instance_SCALE_OUT/.meta__py__VNF_Instance_SCALE_OUT.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata>
+    <map>
+        <entry>
+            <key>DISPLAYNAME</key>
+            <value>_py__VNF_Instance_SCALE_OUT.xml</value>
+        </entry>
+        <entry>
+            <key>DATE_MODIFICATION</key>
+            <value>1643962491552</value>
+        </entry>
+        <entry>
+            <key>REPOSITORY</key>
+            <value>Process</value>
+        </entry>
+        <entry>
+            <key>DATE_CREATION</key>
+            <value>1643962491546</value>
+        </entry>
+        <entry>
+            <key>MODEL</key>
+            <value>0</value>
+        </entry>
+        <entry>
+            <key>TAG</key>
+        </entry>
+        <entry>
+            <key>FILE_TYPE</key>
+            <value>text</value>
+        </entry>
+        <entry>
+            <key>MANUFACTURER</key>
+            <value>0</value>
+        </entry>
+        <entry>
+            <key>TYPE</key>
+            <value>FILE</value>
+        </entry>
+        <entry>
+            <key>COMMENT</key>
+        </entry>
+    </map>
+</metadata>

--- a/ETSI/Python/_py__VNF_Instance_SCALE_OUT/Process_Trigger_automatic_scaling_operation/.meta_Tasks
+++ b/ETSI/Python/_py__VNF_Instance_SCALE_OUT/Process_Trigger_automatic_scaling_operation/.meta_Tasks
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata>
+    <map>
+        <entry>
+            <key>DISPLAYNAME</key>
+            <value>Tasks</value>
+        </entry>
+        <entry>
+            <key>DATE_MODIFICATION</key>
+            <value>1642006736928</value>
+        </entry>
+        <entry>
+            <key>REPOSITORY</key>
+            <value>Process</value>
+        </entry>
+        <entry>
+            <key>DATE_CREATION</key>
+            <value>1642006736925</value>
+        </entry>
+        <entry>
+            <key>TAG</key>
+        </entry>
+        <entry>
+            <key>TYPE</key>
+            <value>DIRECTORY</value>
+        </entry>
+        <entry>
+            <key>COMMENT</key>
+        </entry>
+    </map>
+</metadata>

--- a/ETSI/Python/_py__VNF_Instance_SCALE_OUT/Process_Trigger_automatic_scaling_operation/Tasks/.meta_Task_Trigger_automatic_VNF_Instance_scaling__Out_In__operation.py
+++ b/ETSI/Python/_py__VNF_Instance_SCALE_OUT/Process_Trigger_automatic_scaling_operation/Tasks/.meta_Task_Trigger_automatic_VNF_Instance_scaling__Out_In__operation.py
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata>
+    <map>
+        <entry>
+            <key>DISPLAYNAME</key>
+            <value>Task_Trigger_automatic_VNF_Instance_scaling__Out_In__operation.py</value>
+        </entry>
+        <entry>
+            <key>DATE_MODIFICATION</key>
+            <value>1643962490357</value>
+        </entry>
+        <entry>
+            <key>REPOSITORY</key>
+            <value>Process</value>
+        </entry>
+        <entry>
+            <key>DATE_CREATION</key>
+            <value>1643962490354</value>
+        </entry>
+        <entry>
+            <key>TAG</key>
+        </entry>
+        <entry>
+            <key>FILE_TYPE</key>
+            <value>text</value>
+        </entry>
+        <entry>
+            <key>TYPE</key>
+            <value>UPLOAD</value>
+        </entry>
+        <entry>
+            <key>COMMENT</key>
+        </entry>
+    </map>
+</metadata>

--- a/ETSI/Python/_py__VNF_Instance_SCALE_OUT/Process_Trigger_automatic_scaling_operation/Tasks/Task_Trigger_automatic_VNF_Instance_scaling__Out_In__operation.py
+++ b/ETSI/Python/_py__VNF_Instance_SCALE_OUT/Process_Trigger_automatic_scaling_operation/Tasks/Task_Trigger_automatic_VNF_Instance_scaling__Out_In__operation.py
@@ -1,0 +1,103 @@
+import json
+import time
+from msa_sdk import constants
+from msa_sdk.orchestration import Orchestration
+from msa_sdk.variables import Variables
+from msa_sdk.msa_api import MSA_API
+from msa_sdk.device import Device
+
+'''
+allows to get configuration variable value.
+'''
+def _get_configuration_variable(device, name):
+    value = ''
+    ret = device.get_configuration_variable(name)
+    if 'value' in ret:
+        value = ret.get('value')
+        return value
+    return ''
+
+'''
+Retrieve process instance by service instance ID.
+
+@param orch:
+    Ochestration class object reference.
+@param service_id:
+    Baseline workflow service instance ID.
+@param timeout:
+    loop duration before to break.
+@param interval:
+    loop time interval.
+@return:
+    Response of the get process instance execution.
+'''
+def get_process_instance(orch, process_id, timeout = 600, interval=5):
+    response = {}
+    global_timeout = time.time() + timeout
+    while True:
+        #get service instance execution status.
+        orch.get_process_instance(process_id)
+        response = json.loads(orch.content)
+        status = response.get('status').get('status')
+        #context.update(get_process_instance=status)
+        if status != constants.RUNNING or time.time() > global_timeout:
+            break
+        time.sleep(interval)
+
+    return response
+
+if __name__ == "__main__":
+
+    dev_var = Variables()
+    dev_var.add('customer_id', var_type='String')
+    dev_var.add('device_id', var_type='Device')
+    dev_var.add('rawlog', var_type='String')
+    context = Variables.task_call(dev_var)
+    
+    #Get device id (router) from context.
+    device_id = context['device_id'][3:]
+    
+    #Initiate orchestraction object.
+    ubiqube_id = context['UBIQUBEID']
+    orch = Orchestration(ubiqube_id)
+    
+    #Initiate Device object
+    device = Device(device_id=device_id)
+    
+    #Static Routing Management WF service name constant variable.
+    SERVICE_NAME = 'Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/_py__VNF_LCM__VNFD_based-on_SOL001_'
+    SCALE_OUT_PROCESS_NAME = 'Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF'
+    service_id = ''
+    service_ext_ref = ''
+    
+    #Prepare the VNF LCM WF scale out input parameter as API body.
+    
+    aspectId = "vsrx" #this value is defined in the VNF Descriptor (.csar file).
+    numberOfSteps = "1" #Default value.
+    
+    data = dict(aspectId=aspectId, numberOfSteps=numberOfSteps)
+    
+    if isinstance(data, dict):
+        try:
+            config_var_vnflcm_wf_service_instance_ref = "vnflcm_wf_service_instance_ref"
+            service_ext_ref = _get_configuration_variable(device, config_var_vnflcm_wf_service_instance_ref)
+            context.update(config_var_vnflcm_wf_service_instance_ref=config_var_vnflcm_wf_service_instance_ref)
+        except:
+            MSA_API.task_error('vnflcm service instance reference variable (' + config_var_vnflcm_wf_service_instance_ref + ') is missing from ME=' + device_id, context, True)
+        
+        if not service_ext_ref:
+            MSA_API.task_error('VNF LCM Service instance reference is missing from ME config vars: id=' + device_id, context, True)
+        #execute service by ref.
+        orch.execute_service_by_reference(ubiqube_id, service_ext_ref, SERVICE_NAME, SCALE_OUT_PROCESS_NAME, data)
+        response = json.loads(orch.content)
+        context.update(vnflcm_response=response)
+        service_id = response.get('serviceId').get('id')
+        process_id = response.get('processId').get('id')
+        #get service process details.
+        response = get_process_instance(orch, process_id)
+        status = response.get('status').get('status')
+        details = response.get('status').get('details')
+        if status == constants.FAILED:
+            MSA_API.task_error('Execute service operation is failed: ' + details + ' (#' + str(service_id) + ')', context, True)
+        
+    MSA_API.task_success( 'VNF Instance SCALE_OUT operation is successfully executed.', context, True)

--- a/ETSI/Python/_py__VNF_Instance_SCALE_OUT/_py__VNF_Instance_SCALE_OUT.xml
+++ b/ETSI/Python/_py__VNF_Instance_SCALE_OUT/_py__VNF_Instance_SCALE_OUT.xml
@@ -1,0 +1,28 @@
+<ObjectDefinition>
+  <variables frozen="0">
+    <variable displayName="customer_id" name="params.customer_id" startIncrement="0" type="String" mandatoryArray="false" visible="true" description="" groupSeparator="" groupDisplayName="" displayOrder="0" increment="0" refServiceURI="" keepOnImport="false" editable="false" onlyDetailView="false" localVarNameMatch="" remoteVarNameMatch="" arrayCanAdd="true" arrayCanRemove="true" arrayCanMove="true" arrayCanEdit="true" displayNameHeader="" fullDisplayName="" isMandatory="false" isUserLocked="false" isGrouped="false" isSearchable="false" isUniqueGlobal="false"/>
+    <variable displayName="device_id" name="params.device_id" startIncrement="0" type="Device" mandatoryArray="false" visible="true" description="" groupSeparator="" groupDisplayName="" displayOrder="0" increment="0" refServiceURI="" keepOnImport="false" editable="false" onlyDetailView="false" localVarNameMatch="" remoteVarNameMatch="" arrayCanAdd="true" arrayCanRemove="true" arrayCanMove="true" arrayCanEdit="true" displayNameHeader="" fullDisplayName="" isMandatory="false" isUserLocked="false" isGrouped="false" isSearchable="false" isUniqueGlobal="false"/>
+    <variable displayName="rawlog" name="params.rawlog" startIncrement="0" type="String" mandatoryArray="false" visible="true" description="" groupSeparator="" groupDisplayName="" displayOrder="0" increment="0" refServiceURI="" keepOnImport="false" editable="false" onlyDetailView="false" localVarNameMatch="" remoteVarNameMatch="" arrayCanAdd="true" arrayCanRemove="true" arrayCanMove="true" arrayCanEdit="true" displayNameHeader="" fullDisplayName="" isMandatory="false" isUserLocked="false" isGrouped="false" isSearchable="false" isUniqueGlobal="false"/>
+  </variables>
+  <example/>
+  <process name="Process/Telekom_Malaysia/_py__VNF_Instance_SCALE_OUT/Process_Trigger_automatic_scaling_operation">
+    <displayName>SCALE_OUT VNF Instance</displayName>
+    <type>CREATE</type>
+    <visibility>5</visibility>
+    <allowSchedule/>
+    <task name="Task_Trigger_automatic_VNF_Instance_scaling__Out_In__operation.py">
+      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_Instance_SCALE_OUT/Process_Trigger_automatic_scaling_operation/Tasks</processPath>
+      <displayName>Trigger automatic VNF Instance scaling (Out/In) operation</displayName>
+    </task>
+  </process>
+  <information>
+    <icon/>
+    <description>This workflow allows to schedule automatic VNF Scale OUT operation based-on alarm management.</description>
+    <displayField>service_id</displayField>
+    <serviceTaskType>python</serviceTaskType>
+    <order>10000</order>
+    <visibility>5</visibility>
+    <name>[Py] VNF Instance SCALE_OUT</name>
+    <group>ETSI|PYTHON|VNF</group>
+  </information>
+</ObjectDefinition>

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/.meta_Process_Scale-in_VNF
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/.meta_Process_Scale-in_VNF
@@ -3,11 +3,11 @@
     <map>
         <entry>
             <key>DISPLAYNAME</key>
-            <value>_py__VNF_LCM__VNFD_based-on_SOL001_.xml</value>
+            <value>Process_Scale-in_VNF</value>
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1643909193247</value>
+            <value>1643902985925</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,26 +15,14 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1643909193243</value>
-        </entry>
-        <entry>
-            <key>MODEL</key>
-            <value>0</value>
+            <value>1643902985923</value>
         </entry>
         <entry>
             <key>TAG</key>
         </entry>
         <entry>
-            <key>FILE_TYPE</key>
-            <value>unknown</value>
-        </entry>
-        <entry>
-            <key>MANUFACTURER</key>
-            <value>0</value>
-        </entry>
-        <entry>
             <key>TYPE</key>
-            <value>FILE</value>
+            <value>DIRECTORY</value>
         </entry>
         <entry>
             <key>COMMENT</key>

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/.meta_Process_Scale-out_VNF
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/.meta_Process_Scale-out_VNF
@@ -3,11 +3,11 @@
     <map>
         <entry>
             <key>DISPLAYNAME</key>
-            <value>_py__VNF_LCM__VNFD_based-on_SOL001_.xml</value>
+            <value>Process_Scale-out_VNF</value>
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1643909193247</value>
+            <value>1643902958242</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,26 +15,14 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1643909193243</value>
-        </entry>
-        <entry>
-            <key>MODEL</key>
-            <value>0</value>
+            <value>1643902958240</value>
         </entry>
         <entry>
             <key>TAG</key>
         </entry>
         <entry>
-            <key>FILE_TYPE</key>
-            <value>unknown</value>
-        </entry>
-        <entry>
-            <key>MANUFACTURER</key>
-            <value>0</value>
-        </entry>
-        <entry>
             <key>TYPE</key>
-            <value>FILE</value>
+            <value>DIRECTORY</value>
         </entry>
         <entry>
             <key>COMMENT</key>

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/.meta_Process_Scale_OUT
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/.meta_Process_Scale_OUT
@@ -3,11 +3,11 @@
     <map>
         <entry>
             <key>DISPLAYNAME</key>
-            <value>_py__VNF_LCM__VNFD_based-on_SOL001_.xml</value>
+            <value>Process_Scale_OUT</value>
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1643909193247</value>
+            <value>1643902906917</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,26 +15,14 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1643909193243</value>
-        </entry>
-        <entry>
-            <key>MODEL</key>
-            <value>0</value>
+            <value>1643902906915</value>
         </entry>
         <entry>
             <key>TAG</key>
         </entry>
         <entry>
-            <key>FILE_TYPE</key>
-            <value>unknown</value>
-        </entry>
-        <entry>
-            <key>MANUFACTURER</key>
-            <value>0</value>
-        </entry>
-        <entry>
             <key>TYPE</key>
-            <value>FILE</value>
+            <value>DIRECTORY</value>
         </entry>
         <entry>
             <key>COMMENT</key>

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/.meta_Tasks
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/.meta_Tasks
@@ -3,11 +3,11 @@
     <map>
         <entry>
             <key>DISPLAYNAME</key>
-            <value>_py__VNF_LCM__VNFD_based-on_SOL001_.xml</value>
+            <value>Tasks</value>
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1643909193247</value>
+            <value>1643902985961</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,26 +15,14 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1643909193243</value>
-        </entry>
-        <entry>
-            <key>MODEL</key>
-            <value>0</value>
+            <value>1643902985958</value>
         </entry>
         <entry>
             <key>TAG</key>
         </entry>
         <entry>
-            <key>FILE_TYPE</key>
-            <value>unknown</value>
-        </entry>
-        <entry>
-            <key>MANUFACTURER</key>
-            <value>0</value>
-        </entry>
-        <entry>
             <key>TYPE</key>
-            <value>FILE</value>
+            <value>DIRECTORY</value>
         </entry>
         <entry>
             <key>COMMENT</key>

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/Tasks/.meta_Task_Get_VNF_LCM_Operation_State.py
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/Tasks/.meta_Task_Get_VNF_LCM_Operation_State.py
@@ -3,11 +3,11 @@
     <map>
         <entry>
             <key>DISPLAYNAME</key>
-            <value>_py__VNF_LCM__VNFD_based-on_SOL001_.xml</value>
+            <value>Task_Get_VNF_LCM_Operation_State.py</value>
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1643909193247</value>
+            <value>1643904928443</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,26 +15,18 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1643909193243</value>
-        </entry>
-        <entry>
-            <key>MODEL</key>
-            <value>0</value>
+            <value>1643904928440</value>
         </entry>
         <entry>
             <key>TAG</key>
         </entry>
         <entry>
             <key>FILE_TYPE</key>
-            <value>unknown</value>
-        </entry>
-        <entry>
-            <key>MANUFACTURER</key>
-            <value>0</value>
+            <value>text</value>
         </entry>
         <entry>
             <key>TYPE</key>
-            <value>FILE</value>
+            <value>UPLOAD</value>
         </entry>
         <entry>
             <key>COMMENT</key>

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/Tasks/.meta_Task_Scale-in_VNF_Instance.py
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/Tasks/.meta_Task_Scale-in_VNF_Instance.py
@@ -3,11 +3,11 @@
     <map>
         <entry>
             <key>DISPLAYNAME</key>
-            <value>_py__VNF_LCM__VNFD_based-on_SOL001_.xml</value>
+            <value>Task_Scale-in_VNF_Instance.py</value>
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1643909193247</value>
+            <value>1643909192497</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,26 +15,18 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1643909193243</value>
-        </entry>
-        <entry>
-            <key>MODEL</key>
-            <value>0</value>
+            <value>1643909192494</value>
         </entry>
         <entry>
             <key>TAG</key>
         </entry>
         <entry>
             <key>FILE_TYPE</key>
-            <value>unknown</value>
-        </entry>
-        <entry>
-            <key>MANUFACTURER</key>
-            <value>0</value>
+            <value>text</value>
         </entry>
         <entry>
             <key>TYPE</key>
-            <value>FILE</value>
+            <value>UPLOAD</value>
         </entry>
         <entry>
             <key>COMMENT</key>

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/Tasks/.meta_Task_Sync_to_NFVO_and_VNFM.py
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/Tasks/.meta_Task_Sync_to_NFVO_and_VNFM.py
@@ -3,11 +3,11 @@
     <map>
         <entry>
             <key>DISPLAYNAME</key>
-            <value>_py__VNF_LCM__VNFD_based-on_SOL001_.xml</value>
+            <value>Task_Sync_to_NFVO_and_VNFM.py</value>
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1643909193247</value>
+            <value>1643904980164</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,26 +15,18 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1643909193243</value>
-        </entry>
-        <entry>
-            <key>MODEL</key>
-            <value>0</value>
+            <value>1643904980162</value>
         </entry>
         <entry>
             <key>TAG</key>
         </entry>
         <entry>
             <key>FILE_TYPE</key>
-            <value>unknown</value>
-        </entry>
-        <entry>
-            <key>MANUFACTURER</key>
-            <value>0</value>
+            <value>text</value>
         </entry>
         <entry>
             <key>TYPE</key>
-            <value>FILE</value>
+            <value>UPLOAD</value>
         </entry>
         <entry>
             <key>COMMENT</key>

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/Tasks/Task_Get_VNF_LCM_Operation_State.py
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/Tasks/Task_Get_VNF_LCM_Operation_State.py
@@ -1,0 +1,23 @@
+from msa_sdk.variables import Variables
+from msa_sdk.msa_api import MSA_API
+from msa_sdk.order import Order
+
+if __name__ == "__main__":
+
+    dev_var = Variables()
+    context = Variables.task_call(dev_var)
+
+    nfvo_short_id = context["nfvo_device"][3:]
+    vnfm_short_id = context["vnfm_device"][3:]
+
+    order1 = Order(str(nfvo_short_id))
+    order1.command_synchronize(timeout=60)
+    
+    order2 = Order(str(vnfm_short_id))
+    order2.command_synchronize(timeout=60)
+
+    ret = MSA_API.process_content('ENDED',
+        f'Devices {context["nfvo_device"]} {context["vnfm_device"]} synchronized',
+        context, True)
+
+    print(ret)

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/Tasks/Task_Scale-in_VNF_Instance.py
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/Tasks/Task_Scale-in_VNF_Instance.py
@@ -1,0 +1,46 @@
+import json
+from msa_sdk import constants
+from msa_sdk.variables import Variables
+from msa_sdk.msa_api import MSA_API
+from msa_sdk import constants
+
+from custom.ETSI.VnfLcmSol003 import VnfLcmSol003
+
+
+if __name__ == "__main__":
+
+    dev_var = Variables()
+    dev_var.add('aspectId', var_type='String')
+    dev_var.add('numberOfSteps', var_type='String')
+    context = Variables.task_call(dev_var)
+
+    vnfLcm = VnfLcmSol003(context["mano_ip"], context["mano_port"])
+    vnfLcm.set_parameters(context['mano_user'], context['mano_pass'])
+    
+    aspectId = context.get('aspectId')
+    if not aspectId:
+    	aspectId = 'aspect'
+    
+    numberOfSteps = context.get('numberOfSteps')
+    if not numberOfSteps:
+    	numberOfSteps = '1'
+    
+    content = {
+               "type": "SCALE_IN",
+               "aspectId": aspectId,
+               "numberOfSteps": numberOfSteps,
+               "additionalParams": {}
+               }
+    
+    r = vnfLcm.vnf_lcm_scale_instance_vnf(context["vnf_instance_id"], content)
+    
+    location = ''
+    try:
+        location = r.headers['Location']
+    except:
+        MSA_API.task_error('Stop VNF Instance message: ' + json.dumps(r.json()), context)
+    
+    context["vnf_lcm_op_occ_id"] = location.split("/")[-1]
+    
+    ret = MSA_API.process_content(vnfLcm.state, f'{r}', context, True)
+    print(ret)

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/Tasks/Task_Sync_to_NFVO_and_VNFM.py
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/Tasks/Task_Sync_to_NFVO_and_VNFM.py
@@ -1,0 +1,23 @@
+from msa_sdk.variables import Variables
+from msa_sdk.msa_api import MSA_API
+from msa_sdk.order import Order
+
+if __name__ == "__main__":
+
+    dev_var = Variables()
+    context = Variables.task_call(dev_var)
+
+    nfvo_short_id = context["nfvo_device"][3:]
+    vnfm_short_id = context["vnfm_device"][3:]
+
+    order1 = Order(str(nfvo_short_id))
+    order1.command_synchronize(timeout=60)
+    
+    order2 = Order(str(vnfm_short_id))
+    order2.command_synchronize(timeout=60)
+
+    ret = MSA_API.process_content('ENDED',
+        f'Devices {context["nfvo_device"]} {context["vnfm_device"]} synchronized',
+        context, True)
+
+    print(ret)

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/.meta_Tasks
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/.meta_Tasks
@@ -3,11 +3,11 @@
     <map>
         <entry>
             <key>DISPLAYNAME</key>
-            <value>_py__VNF_LCM__VNFD_based-on_SOL001_.xml</value>
+            <value>Tasks</value>
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1643909193247</value>
+            <value>1643902958284</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,26 +15,14 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1643909193243</value>
-        </entry>
-        <entry>
-            <key>MODEL</key>
-            <value>0</value>
+            <value>1643902958281</value>
         </entry>
         <entry>
             <key>TAG</key>
         </entry>
         <entry>
-            <key>FILE_TYPE</key>
-            <value>unknown</value>
-        </entry>
-        <entry>
-            <key>MANUFACTURER</key>
-            <value>0</value>
-        </entry>
-        <entry>
             <key>TYPE</key>
-            <value>FILE</value>
+            <value>DIRECTORY</value>
         </entry>
         <entry>
             <key>COMMENT</key>

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/Tasks/.meta_Task_Get_VNF_LCM_Operation_State.py
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/Tasks/.meta_Task_Get_VNF_LCM_Operation_State.py
@@ -3,11 +3,11 @@
     <map>
         <entry>
             <key>DISPLAYNAME</key>
-            <value>_py__VNF_LCM__VNFD_based-on_SOL001_.xml</value>
+            <value>Task_Get_VNF_LCM_Operation_State.py</value>
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1643909193247</value>
+            <value>1643904884776</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,26 +15,18 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1643909193243</value>
-        </entry>
-        <entry>
-            <key>MODEL</key>
-            <value>0</value>
+            <value>1643904884774</value>
         </entry>
         <entry>
             <key>TAG</key>
         </entry>
         <entry>
             <key>FILE_TYPE</key>
-            <value>unknown</value>
-        </entry>
-        <entry>
-            <key>MANUFACTURER</key>
-            <value>0</value>
+            <value>text</value>
         </entry>
         <entry>
             <key>TYPE</key>
-            <value>FILE</value>
+            <value>UPLOAD</value>
         </entry>
         <entry>
             <key>COMMENT</key>

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/Tasks/.meta_Task_Scale-out_VNF_Instance.py
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/Tasks/.meta_Task_Scale-out_VNF_Instance.py
@@ -3,11 +3,11 @@
     <map>
         <entry>
             <key>DISPLAYNAME</key>
-            <value>_py__VNF_LCM__VNFD_based-on_SOL001_.xml</value>
+            <value>Task_Scale-out_VNF_Instance.py</value>
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1643909193247</value>
+            <value>1643909185216</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,26 +15,18 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1643909193243</value>
-        </entry>
-        <entry>
-            <key>MODEL</key>
-            <value>0</value>
+            <value>1643909185214</value>
         </entry>
         <entry>
             <key>TAG</key>
         </entry>
         <entry>
             <key>FILE_TYPE</key>
-            <value>unknown</value>
-        </entry>
-        <entry>
-            <key>MANUFACTURER</key>
-            <value>0</value>
+            <value>text</value>
         </entry>
         <entry>
             <key>TYPE</key>
-            <value>FILE</value>
+            <value>UPLOAD</value>
         </entry>
         <entry>
             <key>COMMENT</key>

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/Tasks/.meta_Task_Sync_to_NFVO_and_VNFM.py
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/Tasks/.meta_Task_Sync_to_NFVO_and_VNFM.py
@@ -3,11 +3,11 @@
     <map>
         <entry>
             <key>DISPLAYNAME</key>
-            <value>_py__VNF_LCM__VNFD_based-on_SOL001_.xml</value>
+            <value>Task_Sync_to_NFVO_and_VNFM.py</value>
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1643909193247</value>
+            <value>1643904971500</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,26 +15,18 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1643909193243</value>
-        </entry>
-        <entry>
-            <key>MODEL</key>
-            <value>0</value>
+            <value>1643904971498</value>
         </entry>
         <entry>
             <key>TAG</key>
         </entry>
         <entry>
             <key>FILE_TYPE</key>
-            <value>unknown</value>
-        </entry>
-        <entry>
-            <key>MANUFACTURER</key>
-            <value>0</value>
+            <value>text</value>
         </entry>
         <entry>
             <key>TYPE</key>
-            <value>FILE</value>
+            <value>UPLOAD</value>
         </entry>
         <entry>
             <key>COMMENT</key>

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/Tasks/Task_Get_VNF_LCM_Operation_State.py
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/Tasks/Task_Get_VNF_LCM_Operation_State.py
@@ -1,0 +1,23 @@
+from msa_sdk.variables import Variables
+from msa_sdk.msa_api import MSA_API
+from msa_sdk.order import Order
+
+if __name__ == "__main__":
+
+    dev_var = Variables()
+    context = Variables.task_call(dev_var)
+
+    nfvo_short_id = context["nfvo_device"][3:]
+    vnfm_short_id = context["vnfm_device"][3:]
+
+    order1 = Order(str(nfvo_short_id))
+    order1.command_synchronize(timeout=60)
+    
+    order2 = Order(str(vnfm_short_id))
+    order2.command_synchronize(timeout=60)
+
+    ret = MSA_API.process_content('ENDED',
+        f'Devices {context["nfvo_device"]} {context["vnfm_device"]} synchronized',
+        context, True)
+
+    print(ret)

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/Tasks/Task_Scale-out_VNF_Instance.py
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/Tasks/Task_Scale-out_VNF_Instance.py
@@ -1,0 +1,46 @@
+import json
+from msa_sdk import constants
+from msa_sdk.variables import Variables
+from msa_sdk.msa_api import MSA_API
+from msa_sdk import constants
+
+from custom.ETSI.VnfLcmSol003 import VnfLcmSol003
+
+
+if __name__ == "__main__":
+
+    dev_var = Variables()
+    dev_var.add('aspectId', var_type='String')
+    dev_var.add('numberOfSteps', var_type='String')
+    context = Variables.task_call(dev_var)
+
+    vnfLcm = VnfLcmSol003(context["mano_ip"], context["mano_port"])
+    vnfLcm.set_parameters(context['mano_user'], context['mano_pass'])
+    
+    aspectId = context.get('aspectId')
+    if not aspectId:
+    	aspectId = 'aspect'
+    
+    numberOfSteps = context.get('numberOfSteps')
+    if not numberOfSteps:
+    	numberOfSteps = '1'
+    
+    content = {
+               "type": "SCALE_OUT",
+               "aspectId": aspectId,
+               "numberOfSteps": numberOfSteps,
+               "additionalParams": {}
+               }
+    
+    r = vnfLcm.vnf_lcm_scale_instance_vnf(context["vnf_instance_id"], content)
+    
+    location = ''
+    try:
+        location = r.headers['Location']
+    except:
+        MSA_API.task_error('Stop VNF Instance message: ' + json.dumps(r.json()), context)
+    
+    context["vnf_lcm_op_occ_id"] = location.split("/")[-1]
+    
+    ret = MSA_API.process_content(vnfLcm.state, f'{r}', context, True)
+    print(ret)

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/Tasks/Task_Sync_to_NFVO_and_VNFM.py
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/Tasks/Task_Sync_to_NFVO_and_VNFM.py
@@ -1,0 +1,23 @@
+from msa_sdk.variables import Variables
+from msa_sdk.msa_api import MSA_API
+from msa_sdk.order import Order
+
+if __name__ == "__main__":
+
+    dev_var = Variables()
+    context = Variables.task_call(dev_var)
+
+    nfvo_short_id = context["nfvo_device"][3:]
+    vnfm_short_id = context["vnfm_device"][3:]
+
+    order1 = Order(str(nfvo_short_id))
+    order1.command_synchronize(timeout=60)
+    
+    order2 = Order(str(vnfm_short_id))
+    order2.command_synchronize(timeout=60)
+
+    ret = MSA_API.process_content('ENDED',
+        f'Devices {context["nfvo_device"]} {context["vnfm_device"]} synchronized',
+        context, True)
+
+    print(ret)

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale_OUT/.meta_Tasks
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale_OUT/.meta_Tasks
@@ -3,11 +3,11 @@
     <map>
         <entry>
             <key>DISPLAYNAME</key>
-            <value>_py__VNF_LCM__VNFD_based-on_SOL001_.xml</value>
+            <value>Tasks</value>
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1643909193247</value>
+            <value>1643902906956</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,26 +15,14 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1643909193243</value>
-        </entry>
-        <entry>
-            <key>MODEL</key>
-            <value>0</value>
+            <value>1643902906951</value>
         </entry>
         <entry>
             <key>TAG</key>
         </entry>
         <entry>
-            <key>FILE_TYPE</key>
-            <value>unknown</value>
-        </entry>
-        <entry>
-            <key>MANUFACTURER</key>
-            <value>0</value>
-        </entry>
-        <entry>
             <key>TYPE</key>
-            <value>FILE</value>
+            <value>DIRECTORY</value>
         </entry>
         <entry>
             <key>COMMENT</key>

--- a/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/_py__VNF_LCM__VNFD_based-on_SOL001_.xml
+++ b/ETSI/Python/_py__VNF_LCM__VNFD_based-on_SOL001_/_py__VNF_LCM__VNFD_based-on_SOL001_.xml
@@ -30,6 +30,8 @@
     <variable displayName="is_vnf_instance_exist" name="params.is_vnf_instance_exist" startIncrement="0" type="Boolean" mandatoryArray="false" visible="true" description="" groupSeparator="" groupDisplayName="" displayOrder="0" increment="0" refServiceURI="" keepOnImport="false" editable="false" onlyDetailView="false" localVarNameMatch="" remoteVarNameMatch="" arrayCanAdd="true" arrayCanRemove="true" arrayCanMove="true" arrayCanEdit="true" displayNameHeader="" fullDisplayName="" default="false" isMandatory="false" isUserLocked="false" isGrouped="false" isSearchable="false" isUniqueGlobal="false"/>
     <variable displayName="vnf_instance_id" name="params.vnf_instance_id" startIncrement="0" type="String" mandatoryArray="false" visible="true" description="" groupSeparator="" groupDisplayName="" displayOrder="0" increment="0" refServiceURI="" keepOnImport="false" editable="false" onlyDetailView="false" localVarNameMatch="" remoteVarNameMatch="" arrayCanAdd="true" arrayCanRemove="true" arrayCanMove="true" arrayCanEdit="true" displayNameHeader="" fullDisplayName="" isMandatory="false" isUserLocked="false" isGrouped="false" isSearchable="false" isUniqueGlobal="false"/>
     <variable displayName="ns_service_instance_ref" name="params.ns_service_instance_ref" startIncrement="0" type="String" mandatoryArray="false" visible="true" description="" groupSeparator="" groupDisplayName="" displayOrder="0" increment="0" refServiceURI="" keepOnImport="false" editable="false" onlyDetailView="false" localVarNameMatch="" remoteVarNameMatch="" arrayCanAdd="true" arrayCanRemove="true" arrayCanMove="true" arrayCanEdit="true" displayNameHeader="" fullDisplayName="" isMandatory="false" isUserLocked="false" isGrouped="false" isSearchable="false" isUniqueGlobal="false"/>
+    <variable displayName="aspectId" name="params.aspectId" startIncrement="0" type="String" mandatoryArray="false" visible="true" description="" groupSeparator="" groupDisplayName="" displayOrder="0" increment="0" refServiceURI="" keepOnImport="false" editable="false" onlyDetailView="false" localVarNameMatch="" remoteVarNameMatch="" arrayCanAdd="true" arrayCanRemove="true" arrayCanMove="true" arrayCanEdit="true" displayNameHeader="" fullDisplayName="" isMandatory="false" isUserLocked="false" isGrouped="false" isSearchable="false" isUniqueGlobal="false"/>
+    <variable displayName="numberOfSteps" name="params.numberOfSteps" startIncrement="0" type="String" mandatoryArray="false" visible="true" description="" groupSeparator="" groupDisplayName="" displayOrder="0" increment="0" refServiceURI="" keepOnImport="false" editable="false" onlyDetailView="false" localVarNameMatch="" remoteVarNameMatch="" arrayCanAdd="true" arrayCanRemove="true" arrayCanMove="true" arrayCanEdit="true" displayNameHeader="" fullDisplayName="" isMandatory="false" isUserLocked="false" isGrouped="false" isSearchable="false" isUniqueGlobal="false"/>
   </variables>
   <example/>
   <process name="Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Create_VNF_Instance">
@@ -68,42 +70,6 @@
       <displayName>Create VNF Managed Entities</displayName>
     </task>
   </process>
-  <process name="Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Terminate_VNF">
-    <displayName>Terminate VNF</displayName>
-    <type>UPDATE</type>
-    <visibility>5</visibility>
-    <allowSchedule/>
-    <task name="Task_Terminate_VNF.py">
-      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Terminate_VNF/Tasks</processPath>
-      <displayName>Terminate VNF</displayName>
-    </task>
-    <task name="Task_Get_VNF_LCM_Operation_State.py">
-      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Terminate_VNF/Tasks</processPath>
-      <displayName>Get VNF LCM Operation State</displayName>
-    </task>
-    <task name="Task_Sync_to_NFVO_and_VNFM.py">
-      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Create_VNF_Instance/Tasks</processPath>
-      <displayName>Sync to NFVO and VNFM</displayName>
-    </task>
-  </process>
-  <process name="Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Delete_VNF_Instance">
-    <displayName>Delete VNF Instance</displayName>
-    <type>DELETE</type>
-    <visibility>5</visibility>
-    <allowSchedule/>
-    <task name="Task_Delete_VNF_Instance.py">
-      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Delete_VNF_Instance/Tasks</processPath>
-      <displayName>Delete VNF Instance</displayName>
-    </task>
-    <task name="Task_Sync_to_NFVO_and_VNFM.py">
-      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Create_VNF_Instance/Tasks</processPath>
-      <displayName>Sync to NFVO and VNFM</displayName>
-    </task>
-    <task name="Task_Delete_VNF_Managed_Entities.py">
-      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Terminate_VNF/Tasks</processPath>
-      <displayName>Delete VNF Managed Entities</displayName>
-    </task>
-  </process>
   <process name="Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale_To_Level">
     <displayName>Scale To Level</displayName>
     <type>UPDATE</type>
@@ -119,6 +85,42 @@
     </task>
     <task name="Task_Sync_to_NFVO_and_VNFM.py">
       <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Create_VNF_Instance/Tasks</processPath>
+      <displayName>Sync to NFVO and VNFM</displayName>
+    </task>
+  </process>
+  <process name="Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF">
+    <displayName>Scale-out VNF</displayName>
+    <type>UPDATE</type>
+    <visibility>5</visibility>
+    <allowSchedule/>
+    <task name="Task_Scale-out_VNF_Instance.py">
+      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/Tasks</processPath>
+      <displayName>Scale-out VNF Instance</displayName>
+    </task>
+    <task name="Task_Get_VNF_LCM_Operation_State.py">
+      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/Tasks</processPath>
+      <displayName>Get VNF LCM Operation State</displayName>
+    </task>
+    <task name="Task_Sync_to_NFVO_and_VNFM.py">
+      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-out_VNF/Tasks</processPath>
+      <displayName>Sync to NFVO and VNFM</displayName>
+    </task>
+  </process>
+  <process name="Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF">
+    <displayName>Scale-in VNF</displayName>
+    <type>UPDATE</type>
+    <visibility>5</visibility>
+    <allowSchedule/>
+    <task name="Task_Scale-in_VNF_Instance.py">
+      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/Tasks</processPath>
+      <displayName>Scale-in VNF Instance</displayName>
+    </task>
+    <task name="Task_Get_VNF_LCM_Operation_State.py">
+      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/Tasks</processPath>
+      <displayName>Get VNF LCM Operation State</displayName>
+    </task>
+    <task name="Task_Sync_to_NFVO_and_VNFM.py">
+      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Scale-in_VNF/Tasks</processPath>
       <displayName>Sync to NFVO and VNFM</displayName>
     </task>
   </process>
@@ -166,6 +168,42 @@
     <task name="Task_Sync_VIM.py">
       <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Rebuild_VNF/Tasks</processPath>
       <displayName>Sync VIM</displayName>
+    </task>
+  </process>
+  <process name="Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Terminate_VNF">
+    <displayName>Terminate VNF</displayName>
+    <type>UPDATE</type>
+    <visibility>5</visibility>
+    <allowSchedule/>
+    <task name="Task_Terminate_VNF.py">
+      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Terminate_VNF/Tasks</processPath>
+      <displayName>Terminate VNF</displayName>
+    </task>
+    <task name="Task_Get_VNF_LCM_Operation_State.py">
+      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Terminate_VNF/Tasks</processPath>
+      <displayName>Get VNF LCM Operation State</displayName>
+    </task>
+    <task name="Task_Sync_to_NFVO_and_VNFM.py">
+      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Create_VNF_Instance/Tasks</processPath>
+      <displayName>Sync to NFVO and VNFM</displayName>
+    </task>
+  </process>
+  <process name="Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Delete_VNF_Instance">
+    <displayName>Delete VNF Instance</displayName>
+    <type>DELETE</type>
+    <visibility>5</visibility>
+    <allowSchedule/>
+    <task name="Task_Delete_VNF_Instance.py">
+      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Delete_VNF_Instance/Tasks</processPath>
+      <displayName>Delete VNF Instance</displayName>
+    </task>
+    <task name="Task_Sync_to_NFVO_and_VNFM.py">
+      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Create_VNF_Instance/Tasks</processPath>
+      <displayName>Sync to NFVO and VNFM</displayName>
+    </task>
+    <task name="Task_Delete_VNF_Managed_Entities.py">
+      <processPath>/opt/fmc_repository/Process/Telekom_Malaysia/_py__VNF_LCM__VNFD_based-on_SOL001_/Process_Terminate_VNF/Tasks</processPath>
+      <displayName>Delete VNF Managed Entities</displayName>
     </task>
   </process>
   <information>

--- a/ETSI/Python/src/VnfLcmSol003.py
+++ b/ETSI/Python/src/VnfLcmSol003.py
@@ -34,6 +34,11 @@ class VnfLcmSol003(BaseApi):
         response = self.do_post_return_location(_url, _payload)
         return response
 
+    def vnf_lcm_scale_instance_vnf(self, vnf_instance_id, _payload):
+        _url = self.NSLCM_BASE_URL + "/" + vnf_instance_id + "/scale"
+        response = self.do_post_return_location(_url, _payload)
+        return response
+
     def vnf_lcm_operate_instance_vnf(self, vnf_instance_id, _payload):
         _url = self.NSLCM_BASE_URL + "/" + vnf_instance_id + "/operate"
         response = self.do_post_return_location(_url, _payload)


### PR DESCRIPTION
- Rename Register VNFM and NFVO process.
- add VnfLcm SCALE method in sdk.
- Create _py__VNF_Instance_SCALE_IN to trigger automatic scale-in VNF LCM operation.
- Create _py__VNF_Instance_SCALE_OUT to trigger automatic scale-out VNF LCM operation.
- Create _py__VNF_Instance_HEAL to trigger automatic Healing VNF LCM operation.
- Implemente scale IN and OUT processes in the VNF LCM workflow.
- Merged conflict in _py__VNF_LCM__VNFD_based-on_SOL001_.xml